### PR TITLE
Ability to drop privileges and small fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/udp-broadcast-relay

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+all: udp-broadcast-relay
+.PHONY: all clean
 
 udp-broadcast-relay: main.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -Wall main.c -o udp-broadcast-relay

--- a/udp-broadcast-relay.8
+++ b/udp-broadcast-relay.8
@@ -1,5 +1,5 @@
 .\"                                      Hey, EMACS: -*- nroff -*-
-.TH UDP-BROADCAST-RELAY 8 "September 20, 2003"
+.TH UDP-BROADCAST-RELAY 8 "January 13, 2022"
 .\" Please adjust this date whenever revising the manpage.
 .\"
 .\" Some roff macros, for reference:
@@ -16,7 +16,7 @@
 udp-broadcast-relay \- Relays UDP-Broadcasts to other local networks
 .SH SYNOPSIS
 .B udp-broadcast-relay
-[-f] [-d] id port eth0 eth1 ...
+[-f] [-d] [-u USER] id port eth0 eth1 ...
 .SH DESCRIPTION
 This manual page documents briefly the
 .B udp-broadcast-relay
@@ -29,6 +29,9 @@ Fork program to background
 .TP
 .B \-d
 Enable debugging
+.TP
+.B \-u USER
+Drop privileges to user USER after initialization
 .TP
 .B id
 Number that has to be uniq in each network


### PR DESCRIPTION
This patch series mainly introduces the possibility to drop privileges after initializing all sockets for security reasons.
Thus, the flag "-u" has been introduced for providing a username the program then drops to.
I'm using it with "-u nobody"

Please note that due to the already existing way the arguments are parsed, the parameter may only come after "-f". 

Additionally, the make target "all" has been introduced and has been made phony, including the "clean" target.
Last but not least, the built file is not ignored in .gitignore.
