### PR TITLE
Add an install target and a systemd service file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,20 @@
-all: udp-broadcast-relay
-.PHONY: all clean
-
 udp-broadcast-relay: main.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -Wall main.c -o udp-broadcast-relay
 
+.PHONY: all
+all: udp-broadcast-relay
+
+.PHONY: clean
 clean:
-	rm -f udp-broadcast-relay
+	-$(RM) *.o
+	-$(RM) udp-broadcast-relay
+	-$(RM) build-stamp
+
+.PHONY: install
+install: udp-broadcast-relay
+	install -d $(DESTDIR)/usr/sbin
+	install -d $(DESTDIR)/lib/systemd/system
+	install -d $(DESTDIR)/etc/default
+	install -m 0755 udp-broadcast-relay $(DESTDIR)/usr/sbin
+	install -m 0644 udp-broadcast-relay@.service $(DESTDIR)/lib/systemd/system
+	install -m 0644 udp-broadcast-relay.default $(DESTDIR)/etc/default/udp-broadcast-relay1

--- a/udp-broadcast-relay.default
+++ b/udp-broadcast-relay.default
@@ -1,0 +1,2 @@
+# Uncomment to start UDP bcast relay on the listed interfaces
+DAEMON_ARGS="1900 eth0 eth1 eth2"

--- a/udp-broadcast-relay@.service
+++ b/udp-broadcast-relay@.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=UDP-bcast-relay
+After=network.target
+RequiresMountsFor=/run
+
+[Service]
+Type=simple
+NotifyAccess=main
+EnvironmentFile=-/etc/default/udp-broadcast-relay%I
+ExecStart=/usr/sbin/udp-broadcast-relay $DAEMON_ARGS
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This is a limited version of a much older PR (https://github.com/nomeata/udp-broadcast-relay/pull/7) that excludes the Debian packaging and only includes the two other improvements: a `make install` target and Systemd service files.

Let me know if you want me to change anything.